### PR TITLE
chore: removed protobuf (compvis-6507)

### DIFF
--- a/sas_yolov7/requirements.txt
+++ b/sas_yolov7/requirements.txt
@@ -9,7 +9,6 @@ requests>=2.23.0
 scipy>=1.4.1
 torch>=1.7.0,!=1.12.0
 torchvision>=0.8.1,!=0.13.0
-protobuf<4.21.3
 
 # Logging -------------------------------------
 # wandb


### PR DESCRIPTION
This commit removed protobuf from the requirements.txt file.